### PR TITLE
`sdd-forge check config` コマンドを実装する。`.sdd-forge/config.json` の妥当性を3段階（JSONパース → スキーマ検証 → preset存在確認）で診断し、問題を明確なエラーメッセージで報告する。

### DIFF
--- a/specs/159-check-config-command/draft.md
+++ b/specs/159-check-config-command/draft.md
@@ -1,0 +1,98 @@
+# Draft: sdd-forge check config
+
+**開発種別:** 機能追加（新サブコマンド）
+**目的:** `config.json` の妥当性を診断する `sdd-forge check config` コマンドを実装し、セットアップミスを早期発見できるようにする。
+
+## Q&A
+
+### 1. Goal & Scope
+
+**Q: ゴールとスコープは明確か？**
+
+A: 明確。`sdd-forge check config` を `check` グループの新サブコマンドとして追加する。
+検証対象は `.sdd-forge/config.json` のみ。次の3種類のチェックを行う：
+
+1. **スキーマ検証** — 既存の `validateConfig()` を呼び出してエラーを収集
+2. **preset 存在確認** — `type` フィールドに指定されたプリセットが `src/presets/` 内に存在するか
+3. **JSON パース** — ファイルの存在・JSON パースエラーを最初に確認
+
+スコープ外: `analysis.json` の検証、`flow.json` の検証（別コマンドで対応すべき）。
+
+---
+
+### 2. Impact on Existing Code
+
+**Q: 既存コードへの影響は？**
+
+A: 最小限。
+
+- `src/check.js` の `SCRIPTS` マップに `config: "check/commands/config.js"` を追加する（1行）
+- 新規ファイル `src/check/commands/config.js` を作成
+- `validateConfig()` は既存のまま変更なし（再利用）
+- `PRESETS` / `resolveChain()` は既存のまま変更なし（再利用）
+
+---
+
+### 3. Constraints
+
+**Q: 非機能要件・制約は？**
+
+A:
+- 外部依存なし（Node.js 組み込みのみ）
+- `scan.js` のパターンに倣う（`parseArgs`, `runIfDirect`, `EXIT_ERROR`）
+- `--format text|json` をサポート（md は不要：診断コマンドなので）
+- config が存在しない場合もクラッシュせず、エラーとして報告する
+
+---
+
+### 4. Edge Cases
+
+**Q: エッジケースは？**
+
+A:
+| ケース | 動作 |
+|--------|------|
+| `config.json` が存在しない | エラー報告して exit 1 |
+| JSON パース失敗 | エラー報告して exit 1 |
+| スキーマエラーあり | 全エラーを列挙して exit 1 |
+| `type` のプリセットが存在しない | スキーマ PASS でも追加エラーとして報告 |
+| `type` が配列で一部のみ存在しない | 存在しないものだけをエラーとして報告 |
+| 全チェック PASS | "config is valid" を表示して exit 0 |
+
+---
+
+### 5. Test Strategy
+
+**Q: テスト戦略は？**
+
+A: `specs/159-check-config-command/tests/` に検証テストを配置する。
+
+テストするシナリオ：
+- 正常な config.json → exit 0
+- 存在しない config.json → exit 1、エラーメッセージ含む
+- 無効な JSON → exit 1
+- 必須フィールド欠損 → exit 1、欠損フィールド名が出力に含まれる
+- `type` が存在しないプリセット名 → exit 1
+- `--format json` でのJSON出力構造確認
+
+---
+
+### 6. Alternatives Considered
+
+**Q: 他のアプローチは？**
+
+A:
+- **`validateConfig()` をプリセット確認まで含むよう拡張する** → 却下。`types.js` は純粋なバリデーションライブラリでありプリセット探索ロジックを持つべきでない。関心の分離を維持する。
+- **`sdd-forge setup` の一部として検証** → 却下。`check` グループに独立したコマンドとして持つほうが、CI での使用など汎用性が高い。
+
+---
+
+### 7. Future Extensibility
+
+**Q: 将来の拡張への影響は？**
+
+A: `check` グループのパターンを確立する。将来 `sdd-forge check flow` や `sdd-forge check agents` を追加する際も同じ構造で拡張できる。
+
+---
+
+- [x] User approved this draft (autoApprove)

--- a/specs/159-check-config-command/flow.json
+++ b/specs/159-check-config-command/flow.json
@@ -143,7 +143,7 @@
     },
     "impl": {
       "srcRead": 1,
-      "issueLog": 1
+      "issueLog": 2
     }
   }
 }

--- a/specs/159-check-config-command/flow.json
+++ b/specs/159-check-config-command/flow.json
@@ -1,0 +1,149 @@
+{
+  "spec": "specs/159-check-config-command/spec.md",
+  "baseBranch": "main",
+  "featureBranch": "feature/159-check-config-command",
+  "steps": [
+    {
+      "id": "approach",
+      "status": "done"
+    },
+    {
+      "id": "branch",
+      "status": "done"
+    },
+    {
+      "id": "prepare-spec",
+      "status": "pending"
+    },
+    {
+      "id": "draft",
+      "status": "done"
+    },
+    {
+      "id": "gate-draft",
+      "status": "done"
+    },
+    {
+      "id": "spec",
+      "status": "done"
+    },
+    {
+      "id": "gate",
+      "status": "done"
+    },
+    {
+      "id": "approval",
+      "status": "done"
+    },
+    {
+      "id": "test",
+      "status": "done"
+    },
+    {
+      "id": "implement",
+      "status": "done"
+    },
+    {
+      "id": "gate-impl",
+      "status": "done"
+    },
+    {
+      "id": "review",
+      "status": "done"
+    },
+    {
+      "id": "finalize",
+      "status": "pending"
+    },
+    {
+      "id": "commit",
+      "status": "pending"
+    },
+    {
+      "id": "push",
+      "status": "pending"
+    },
+    {
+      "id": "merge",
+      "status": "pending"
+    },
+    {
+      "id": "pr-create",
+      "status": "pending"
+    },
+    {
+      "id": "branch-cleanup",
+      "status": "pending"
+    },
+    {
+      "id": "pr-merge",
+      "status": "pending"
+    },
+    {
+      "id": "sync-cleanup",
+      "status": "pending"
+    },
+    {
+      "id": "docs-update",
+      "status": "pending"
+    },
+    {
+      "id": "docs-review",
+      "status": "pending"
+    },
+    {
+      "id": "docs-commit",
+      "status": "pending"
+    }
+  ],
+  "requirements": [
+    {
+      "desc": "sdd-forge check config コマンドが実行できること",
+      "status": "pending"
+    },
+    {
+      "desc": "config.json が存在しない場合、エラーメッセージを stderr に出力して exit 1 すること",
+      "status": "done"
+    },
+    {
+      "desc": "config.json が無効な JSON の場合、パースエラーを報告して exit 1 すること",
+      "status": "done"
+    },
+    {
+      "desc": "スキーマ検証エラーがある場合、最大50件までエラーを列挙して exit 1 すること",
+      "status": "done"
+    },
+    {
+      "desc": "type に指定されたプリセットが存在しない場合、該当プリセット名を報告して exit 1 すること",
+      "status": "done"
+    },
+    {
+      "desc": "全チェックがパスした場合、config is valid を表示して exit 0 すること",
+      "status": "done"
+    },
+    {
+      "desc": "--format json オプションで JSON 形式の出力ができること",
+      "status": "done"
+    },
+    {
+      "desc": "-h / --help でヘルプを表示すること",
+      "status": "done"
+    }
+  ],
+  "issue": 115,
+  "request": "sdd-forge check config コマンドの実装: config.json の必須フィールド・preset の存在確認・スキーマ整合性を診断する",
+  "worktree": true,
+  "autoApprove": true,
+  "metrics": {
+    "plan": {
+      "docsRead": 1
+    },
+    "draft": {
+      "srcRead": 1
+    },
+    "impl": {
+      "srcRead": 1,
+      "issueLog": 1
+    }
+  }
+}

--- a/specs/159-check-config-command/issue-log.json
+++ b/specs/159-check-config-command/issue-log.json
@@ -1,0 +1,24 @@
+{
+  "entries": [
+    {
+      "step": "gate",
+      "reason": "Single Responsibility — `check config` コマンドの実装のみを対象としており、無関係な変更は含まれていない; Unambiguous Requirements — 各要件に \"exit 1\" \"stderr に出力\" \"全エラーを列挙\" 等の検証可能な条件が明記されている; Complete Context — 各要件はトリガー条件（〜の場合）と期待動作（出力・exit code）がペアで記述されている; No Hardcoded Secrets — 設定ファイルの検証ツールであり、シークレットのハードコードに関する懸念は本仕様の性質上該当しない; No Silent Error Swallowing — エラーは全て報告・exit 1 で処理される設計になっており、サイレント無視は規定されていない; Prioritize Requirements — 要件が8項目あるが、診断チェックの優先順位（JSONパース → スキーマ → preset の早期終了順）はClarificationsに明記されている; Impact on Existing Features — Out of Scope と Alternatives Considered で既存 `validateConfig()` / `PRESETS` の再利用のみであることを明示し、既存機能への影響がないことが読み取れる。ただし「既存機能への影響はなし」の明示的な記述がない — 軽微な不備だが致命的ではないためPASSとする; Bounded Resource Usage — スキーマ検証でエラーを「全エラーを列挙」する際の上限が未定義。大量エラー時の件数上限が規定されていない; Changes Require Test Coverage — テストカバレッジに関する記述が仕様に存在しない。Happy path・エラーケースのテスト有無が不明; Spec Includes Test Strategy — テスト戦略セクションが存在しない（何をどうテストするか未記載）; Synthesize Draft, Do Not Copy — Q&Aからの反映が明記されており、ドラフト内容を整理・抽象化した形跡がある; Record Unresolved Points as Open Questions — Open Questions セクションが存在し \"なし\" と明示されている; Include 'Why This Approach' Rationale — Alternatives Considered に関心の分離を維持する理由が記載されている; Backward — Compatible CLI Interface — 既存コマンドの変更・削除はなく、新規コマンド追加のみのため移行計画は不要; Exit Code Contract — 全エラーケースで exit 1、成功時 exit 0 が明確に規定されている",
+      "trigger": "gate post hook (auto)",
+      "timestamp": "2026-04-08T05:12:37.444Z"
+    },
+    {
+      "step": "gate-impl",
+      "reason": "`sdd — forge check config` コマンドが実行できること — `check.js`に`config`エントリが追加され、`check/commands/config.js`が実装されている; `config.json` が存在しない場合、エラーメッセージを stderr に出力して exit 1 すること — `fs.existsSync`で確認し、stderrへの出力とexit 1が実装されている（text format時）; `config.json` が無効な JSON の場合、パースエラーを報告して exit 1 すること — `JSON.parse`のtry/catchでエラーを捕捉してexit 1する; スキーマ検証エラーがある場合、最大50件までエラーを列挙して exit 1 すること — `MAX_SCHEMA_ERRORS = 50`でslice、失敗時exit 1; `type` に指定されたプリセットが存在しない場合、該当プリセット名を報告して exit 1 すること — `Preset not found: ${t}`メッセージでexit 1; 全チェックがパスした場合、\"config is valid\" を表示して exit 0 すること — `ok`の場合`\"config is valid\\n\"`を出力しexit 0; ` — -format json` オプションで JSON 形式の出力ができること — `{ ok, checks }`構造のJSONをstdoutに出力; ` — h` / `--help` でヘルプを表示すること — `cli.help`判定と`printHelp()`が実装されている; No Hardcoded Secrets — diff and spec contain no API keys, passwords, or tokens.; No Silent Error Swallowing — `sdd-forge.js` contains `} catch { /* ... logs silently skipped */ }` which discards errors without logging or re-throwing.; Bounded Resource Usage — spec explicitly caps schema error enumeration at 50件; no unbounded loops introduced.; No Sensitive Data in Logs — no logging of sensitive fields in diff or spec.; No Disabling Existing Tests — spec places new tests in `specs/159-check-config-command/tests/`; no existing tests touched.; Escalate When New Tests Break Existing Tests — new tests are outside `npm test` scope; no conflict with existing test suite.; Do Not Modify Existing Tests Without Approval — no existing test files modified.; Flag Tests That Become Irrelevant — no feature changes that obsolete existing tests.; Exit Code Contract — spec defines exit 0 on success and exit 1 on all failure conditions explicitly.; No Synchronous I/O in Hot Paths — implementation files (`check.js`, `check/commands/config.js`) not provided in diff; no synchronous I/O introduced in shown changes.; Validate User Input at Entry Point — spec defines `--format` validation (text/json); routing in `sdd-forge.js` delegates to `check.js` dispatcher; implementation files not shown but no unvalidated passthrough visible in diff.",
+      "trigger": "gate post hook (auto)",
+      "timestamp": "2026-04-08T05:52:13.884Z"
+    },
+    {
+      "step": "review",
+      "reason": "gate-impl flags pre-existing silent catch block in sdd-forge.js as No Silent Error Swallowing violation",
+      "trigger": "sdd-forge.js was modified in this spec (adding check to dispatchers), so gate analyzed the entire file including pre-existing catch block",
+      "resolution": "modified catch block to write stderr for unexpected errors while keeping silent for ERR_MISSING_FILE (pre-setup scenario)",
+      "guardrailCandidate": "when modifying any file, gate will analyze all pre-existing code in context — pre-existing guardrail violations in touched files must be fixed",
+      "timestamp": "2026-04-08T05:53:18.824Z"
+    }
+  ]
+}

--- a/specs/159-check-config-command/issue-log.json
+++ b/specs/159-check-config-command/issue-log.json
@@ -19,6 +19,18 @@
       "resolution": "modified catch block to write stderr for unexpected errors while keeping silent for ERR_MISSING_FILE (pre-setup scenario)",
       "guardrailCandidate": "when modifying any file, gate will analyze all pre-existing code in context — pre-existing guardrail violations in touched files must be fixed",
       "timestamp": "2026-04-08T05:53:18.824Z"
+    },
+    {
+      "step": "merge",
+      "reason": "Merge conflict detected. Run 'git rebase main' in the worktree and retry finalize.",
+      "timestamp": "2026-04-08T05:55:00.783Z"
+    },
+    {
+      "step": "finalize",
+      "reason": "merge conflict detected during squash merge — worktree branch diverged from current main",
+      "trigger": "sdd-forge flow run finalize --mode all executed merge step",
+      "resolution": "running git rebase main in worktree and retrying finalize",
+      "timestamp": "2026-04-08T05:55:10.326Z"
     }
   ]
 }

--- a/specs/159-check-config-command/qa.md
+++ b/specs/159-check-config-command/qa.md
@@ -1,0 +1,9 @@
+# Clarification Q&A
+
+- Q: 
+  - A: 
+
+## Confirmation
+- Before implementation, ask the user:
+  - "この仕様で実装して問題ないですか？"
+- If approved, update `spec.md` -> `## User Confirmation` with checked state.

--- a/specs/159-check-config-command/report.json
+++ b/specs/159-check-config-command/report.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "implementation": {
+      "diffStat": "specs/159-check-config-command/draft.md            |  98 +++++++++++\n specs/159-check-config-command/flow.json           | 149 ++++++++++++++++\n specs/159-check-config-command/issue-log.json      |  24 +++\n specs/159-check-config-command/qa.md               |   9 +\n specs/159-check-config-command/review.md           |  38 +++++\n specs/159-check-config-command/spec.md             |  80 +++++++++\n specs/159-check-config-command/tests/README.md     |  29 ++++\n .../tests/check-config.test.js                     | 189 +++++++++++++++++++++\n src/check.js                                       |  39 +++++\n src/check/commands/config.js                       | 140 +++++++++++++++\n src/sdd-forge.js                                   |   8 +-\n 11 files changed, 801 insertions(+), 2 deletions(-)",
+      "commits": [
+        "feat: feature/159-check-config-command"
+      ]
+    },
+    "retro": {
+      "total": 8,
+      "done": 8,
+      "partial": 0,
+      "not_done": 0,
+      "rate": 1,
+      "notes": "全8要件が実装されており、テストコードも specs/159-check-config-command/tests/ に完備。unplanned な変更は2件あるが、どちらも意図的かつ軽微（Logger の silent catch 修正は gate-impl で指摘されたガードレール違反への対応、JSDoc 更新は review で指摘された一貫性修正）。要件の完成度は高い。"
+    },
+    "issueLog": {
+      "count": 0,
+      "entries": []
+    },
+    "metrics": {
+      "docsRead": 1,
+      "srcRead": 2,
+      "question": 0,
+      "issueLog": 1
+    },
+    "tests": null,
+    "sync": {
+      "status": "skipped",
+      "reason": "sync was skipped"
+    }
+  },
+  "text": "  Report\n\n  Implementation\n  ────────────────────────────────────────────────\n    feat: feature/159-check-config-command\n    11 files changed, 801 insertions(+), 2 deletions(-)\n\n  Retro\n  ────────────────────────────────────────────────\n    ████████ 100%  (8 done / 0 partial / 0 miss)\n\n  Metrics\n  ────────────────────────────────────────────────\n    docs read 1  src read 2  Q&A 0  issue-log 1\n\n  Tests\n  ────────────────────────────────────────────────\n    -"
+}

--- a/specs/159-check-config-command/retro.json
+++ b/specs/159-check-config-command/retro.json
@@ -1,0 +1,64 @@
+{
+  "spec": "specs/159-check-config-command/spec.md",
+  "date": "2026-04-08T05:54:59.681Z",
+  "requirements": [
+    {
+      "desc": "sdd-forge check config コマンドが実行できること",
+      "status": "done",
+      "note": "src/check.js に config エントリが追加され、src/check/commands/config.js が実装された。sdd-forge.js の NAMESPACE_DISPATCHERS に 'check' が追加されルーティングも完備"
+    },
+    {
+      "desc": "config.json が存在しない場合、エラーメッセージを stderr に出力して exit 1 すること",
+      "status": "done",
+      "note": "config.js の runChecks() で fs.existsSync チェックを行い、失敗時は stderr に出力して EXIT_ERROR (1) で終了する"
+    },
+    {
+      "desc": "config.json が無効な JSON の場合、パースエラーを報告して exit 1 すること",
+      "status": "done",
+      "note": "JSON.parse を try/catch で囲み、失敗時は err.message を含むエラーを返して exit 1 する"
+    },
+    {
+      "desc": "スキーマ検証エラーがある場合、最大50件までエラーを列挙して exit 1 すること",
+      "status": "done",
+      "note": "MAX_SCHEMA_ERRORS = 50 で slice し、validateConfig() の例外からエラーリストを生成。text format では stderr に列挙して exit 1"
+    },
+    {
+      "desc": "type に指定されたプリセットが存在しない場合、該当プリセット名を報告して exit 1 すること",
+      "status": "done",
+      "note": "PRESETS の key セットと比較し、不明なプリセット名を 'Preset not found: ${t}' として報告。配列 type にも対応"
+    },
+    {
+      "desc": "全チェックがパスした場合、config is valid を表示して exit 0 すること",
+      "status": "done",
+      "note": "ok が true の場合 stdout に 'config is valid\\n' を出力し、process.exit を呼ばず (暗黙の exit 0)"
+    },
+    {
+      "desc": "--format json オプションで JSON 形式の出力ができること",
+      "status": "done",
+      "note": "{ ok, checks } 構造の JSON を stdout に出力。ok=false 時は exit 1、ok=true 時は exit 0"
+    },
+    {
+      "desc": "-h / --help でヘルプを表示すること",
+      "status": "done",
+      "note": "cli.help で printHelp() を呼び出す。check.js レベルでも -h/--help に対応"
+    }
+  ],
+  "unplanned": [
+    {
+      "file": "src/sdd-forge.js",
+      "change": "catch ブロックを修正して ERR_MISSING_FILE 以外のエラーを stderr に出力するよう変更（Logger init の silent error swallowing 修正）。これは要件外だが issue-log.json の review エントリに記録された意図的な修正"
+    },
+    {
+      "file": "src/sdd-forge.js",
+      "change": "ファイル先頭 JSDoc コメントに 'check → src/check.js' の行を追加（ドキュメント同期）"
+    }
+  ],
+  "summary": {
+    "total": 8,
+    "done": 8,
+    "partial": 0,
+    "not_done": 0,
+    "rate": 1,
+    "notes": "全8要件が実装されており、テストコードも specs/159-check-config-command/tests/ に完備。unplanned な変更は2件あるが、どちらも意図的かつ軽微（Logger の silent catch 修正は gate-impl で指摘されたガードレール違反への対応、JSDoc 更新は review で指摘された一貫性修正）。要件の完成度は高い。"
+  }
+}

--- a/specs/159-check-config-command/review.md
+++ b/specs/159-check-config-command/review.md
@@ -1,0 +1,38 @@
+# Code Review Results
+
+### [x] 1. Stale file-level comment in `sdd-forge.js`
+**File:** `src/sdd-forge.js`
+
+**Issue:** The file-level JSDoc comment (lines 6–12) lists the dispatcher routes for `docs` and `flow`, but now that `"check"` has been added to `NAMESPACE_DISPATCHERS`, the comment is out of sync — it will mislead anyone reading the entry point about which dispatchers exist.
+
+**Suggestion:** Add the missing route to the comment to keep documentation consistent with code:
+
+```js
+ *   docs    → src/docs.js
+ *   flow    → src/flow.js
++*   check   → src/check.js
+ *   setup   → src/setup.js
+```
+
+---
+
+**Verdict:** APPROVED
+**Reason:** This is a genuine documentation inconsistency, not merely cosmetic. The JSDoc comment at lines 6–12 explicitly enumerates namespace dispatcher routes as a quick-reference contract for anyone reading the entry point. After `"check"` was added to `NAMESPACE_DISPATCHERS` (confirmed on line 51 of the file), the comment became actively misleading — it implies `check` subcommands don't exist. Keeping a dispatcher enumeration comment in sync with the actual `Set` is a legitimate correctness concern, not padding.
+
+### [ ] 2. Redundant default fallback in `config.js`
+**File:** `src/check/commands/config.js`
+
+**Issue:** Line 108 reads `const format = cli.format || "text";`, but `parseArgs` is already called with `defaults: { format: "text" }` on line 99–101. This means `cli.format` is always `"text"` or a user-supplied value — it can never be falsy. The `|| "text"` guard is dead code that implies the default might not be applied, which is misleading.
+
+**Suggestion:** Remove the redundant fallback:
+
+```js
+// before
+const format = cli.format || "text";
+
+// after
+const format = cli.format;
+```
+
+**Verdict:** REJECTED
+**Reason:** The proposal's premise is incorrect. While `defaults: { format: "text" }` guarantees a non-falsy value when `--format` is *not passed at all*, the `parseArgs` implementation in `src/lib/cli.js` (line 74) stores option values as:

--- a/specs/159-check-config-command/spec.md
+++ b/specs/159-check-config-command/spec.md
@@ -1,0 +1,80 @@
+# Feature Specification: 159-check-config-command
+
+**Feature Branch**: `feature/159-check-config-command`
+**Created**: 2026-04-08
+**Status**: Approved
+**Input**: GitHub Issue #115
+
+## Goal
+
+`sdd-forge check config` コマンドを実装する。`.sdd-forge/config.json` の妥当性を3段階（JSONパース → スキーマ検証 → preset存在確認）で診断し、問題を明確なエラーメッセージで報告する。
+
+## Scope
+
+- `src/check.js` の `SCRIPTS` マップへの `config` エントリ追加
+- `src/check/commands/config.js` の新規作成
+- 出力フォーマット: `text`（デフォルト）、`json`
+- 診断チェック:
+  1. config.json の存在・JSONパース検証
+  2. スキーマ検証（既存 `validateConfig()` を再利用）
+  3. `type` フィールドのプリセット存在確認（既存 `PRESETS` を再利用）
+
+## Out of Scope
+
+- `analysis.json` の検証
+- `flow.json` の検証
+- エージェント設定（`agent.providers[].command`）の実行可能性チェック
+- markdown (`--format md`) 出力
+
+## Clarifications (Q&A)
+
+- Q: `validateConfig()` がスキーマエラーで throw した場合、preset確認は行うか？
+  - A: 行わない。JSONパース失敗またはスキーマエラーがあれば早期終了する。チェック順序を守る。
+- Q: `type` に存在しないプリセット名があった場合の exit code は？
+  - A: exit 1。スキーマが正しくても preset が存在しなければエラーとして扱う。
+- Q: `--format json` の出力構造は？
+  - A: `{ ok: bool, checks: [{ name, result, errors }] }` の形式。`ok` は全チェックがパスした場合のみ true。
+
+## Test Strategy
+
+- `specs/159-check-config-command/tests/` に検証テストを配置する（`npm test` の対象外）
+- テストはコマンドの stdout/stderr/exit code を確認するシナリオテスト形式
+- カバーするシナリオ:
+  - 正常な config.json → exit 0、"config is valid" を含む出力
+  - 存在しない config.json → exit 1、エラーメッセージ
+  - 無効な JSON → exit 1、パースエラー
+  - 必須フィールド欠損 → exit 1、フィールド名を含む出力
+  - 存在しないプリセット名 → exit 1、プリセット名を含む出力
+  - `--format json` → exit code に応じた JSON 出力、`ok` フィールドを含む
+
+## Alternatives Considered
+
+- `validateConfig()` にプリセット確認を組み込む → 却下。`types.js` はバリデーションライブラリであり、プリセット探索（`presets.js`）への依存を持つべきでない。関心の分離を維持する。
+
+## User Confirmation
+
+- [x] User approved this spec
+- Confirmed at: 2026-04-08 (autoApprove)
+- Notes: draft Q&A から反映
+
+## Requirements
+
+1. `sdd-forge check config` コマンドが実行できること
+2. `config.json` が存在しない場合、エラーメッセージを stderr に出力して exit 1 すること
+3. `config.json` が無効な JSON の場合、パースエラーを報告して exit 1 すること
+4. スキーマ検証エラーがある場合、最大50件までエラーを列挙して exit 1 すること
+5. `type` に指定されたプリセットが存在しない場合、該当プリセット名を報告して exit 1 すること
+6. 全チェックがパスした場合、"config is valid" を表示して exit 0 すること
+7. `--format json` オプションで JSON 形式の出力ができること
+8. `-h` / `--help` でヘルプを表示すること
+
+## Acceptance Criteria
+
+- `sdd-forge check config` を正常な config に対して実行すると "config is valid" と表示され exit 0 となる
+- `type: "nonexistent"` の config に対して実行すると "Preset not found: nonexistent" を含むエラーが出力され exit 1 となる
+- `lang` フィールドを欠いた config に対して実行すると `'lang'` を含むエラーが出力され exit 1 となる
+- `--format json` で実行すると JSON が stdout に出力され、`ok` フィールドが含まれる
+
+## Open Questions
+
+- なし

--- a/specs/159-check-config-command/tests/README.md
+++ b/specs/159-check-config-command/tests/README.md
@@ -1,0 +1,29 @@
+# Spec 159: check-config-command — Test Notes
+
+## What Was Tested
+
+`sdd-forge check config` コマンドの全要件（spec 159 Requirements 1〜8）を検証。
+
+- 正常 config での exit 0 / "config is valid" 出力
+- config.json 不存在・無効 JSON での exit 1
+- スキーマエラー（必須フィールド欠損）での exit 1 + エラー列挙
+- 存在しないプリセット名での exit 1 + プリセット名出力
+- `type` 配列で一部 unknown の場合
+- `--format json` での JSON 出力（ok フィールド）
+- `-h` でのヘルプ表示
+
+## Test Location
+
+`specs/159-check-config-command/tests/check-config.test.js`
+
+（`npm test` の対象外。このスペックの要件検証専用）
+
+## How to Run
+
+```bash
+node --test specs/159-check-config-command/tests/check-config.test.js
+```
+
+## Expected Results
+
+実装後に全テストが pass すること（事前実行では `src/check/commands/config.js` が存在しないため全 fail が正常）。

--- a/specs/159-check-config-command/tests/check-config.test.js
+++ b/specs/159-check-config-command/tests/check-config.test.js
@@ -1,0 +1,189 @@
+/**
+ * specs/159-check-config-command/tests/check-config.test.js
+ *
+ * Spec verification tests for `sdd-forge check config`.
+ * These tests verify that the requirements in spec 159 are met.
+ * Run with: node --test specs/159-check-config-command/tests/check-config.test.js
+ */
+
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { join } from "path";
+import { spawnSync } from "child_process";
+import { createTmpDir, removeTmpDir, writeJson, writeFile } from "../../../tests/helpers/tmp-dir.js";
+
+const CMD = join(process.cwd(), "src/check/commands/config.js");
+
+const VALID_CONFIG = {
+  lang: "ja",
+  type: "node-cli",
+  docs: { languages: ["ja"], defaultLanguage: "ja" },
+};
+
+describe("sdd-forge check config", () => {
+  let tmp;
+  afterEach(() => tmp && removeTmpDir(tmp));
+
+  // Requirement 1: command runs
+  it("runs successfully with a valid config", () => {
+    tmp = createTmpDir();
+    writeJson(tmp, ".sdd-forge/config.json", VALID_CONFIG);
+
+    const result = spawnSync("node", [CMD], {
+      encoding: "utf8",
+      env: { ...process.env, SDD_WORK_ROOT: tmp, SDD_SOURCE_ROOT: tmp },
+    });
+
+    assert.equal(result.status, 0, `expected exit 0, got ${result.status}\nstderr: ${result.stderr}`);
+    assert.ok(
+      result.stdout.includes("config is valid"),
+      `expected "config is valid" in stdout:\n${result.stdout}`
+    );
+  });
+
+  // Requirement 2: missing config.json → exit 1
+  it("reports error and exits 1 when config.json does not exist", () => {
+    tmp = createTmpDir();
+
+    const result = spawnSync("node", [CMD], {
+      encoding: "utf8",
+      env: { ...process.env, SDD_WORK_ROOT: tmp, SDD_SOURCE_ROOT: tmp },
+    });
+
+    assert.equal(result.status, 1, `expected exit 1, got ${result.status}`);
+    assert.ok(
+      result.stderr.includes("config") || result.stdout.includes("config"),
+      `expected error message about config:\nstdout: ${result.stdout}\nstderr: ${result.stderr}`
+    );
+  });
+
+  // Requirement 3: invalid JSON → exit 1
+  it("reports parse error and exits 1 when config.json is invalid JSON", () => {
+    tmp = createTmpDir();
+    writeFile(tmp, ".sdd-forge/config.json", "{ invalid json }");
+
+    const result = spawnSync("node", [CMD], {
+      encoding: "utf8",
+      env: { ...process.env, SDD_WORK_ROOT: tmp, SDD_SOURCE_ROOT: tmp },
+    });
+
+    assert.equal(result.status, 1, `expected exit 1, got ${result.status}`);
+  });
+
+  // Requirement 4: schema errors → exit 1, errors listed
+  it("lists missing required field and exits 1", () => {
+    tmp = createTmpDir();
+    writeJson(tmp, ".sdd-forge/config.json", {
+      // lang is missing
+      type: "node-cli",
+      docs: { languages: ["ja"], defaultLanguage: "ja" },
+    });
+
+    const result = spawnSync("node", [CMD], {
+      encoding: "utf8",
+      env: { ...process.env, SDD_WORK_ROOT: tmp, SDD_SOURCE_ROOT: tmp },
+    });
+
+    assert.equal(result.status, 1, `expected exit 1, got ${result.status}`);
+    const output = result.stdout + result.stderr;
+    assert.ok(
+      output.includes("lang"),
+      `expected error mentioning 'lang':\n${output}`
+    );
+  });
+
+  // Requirement 5: unknown preset → exit 1
+  it("reports unknown preset and exits 1 when type is not found", () => {
+    tmp = createTmpDir();
+    writeJson(tmp, ".sdd-forge/config.json", {
+      lang: "ja",
+      type: "nonexistent-preset-xyz",
+      docs: { languages: ["ja"], defaultLanguage: "ja" },
+    });
+
+    const result = spawnSync("node", [CMD], {
+      encoding: "utf8",
+      env: { ...process.env, SDD_WORK_ROOT: tmp, SDD_SOURCE_ROOT: tmp },
+    });
+
+    assert.equal(result.status, 1, `expected exit 1, got ${result.status}`);
+    const output = result.stdout + result.stderr;
+    assert.ok(
+      output.includes("nonexistent-preset-xyz"),
+      `expected preset name in output:\n${output}`
+    );
+  });
+
+  // Requirement 5 (array): multiple types, one unknown
+  it("reports unknown preset when type is an array with unknown entry", () => {
+    tmp = createTmpDir();
+    writeJson(tmp, ".sdd-forge/config.json", {
+      lang: "ja",
+      type: ["node-cli", "bogus-preset"],
+      docs: { languages: ["ja"], defaultLanguage: "ja" },
+    });
+
+    const result = spawnSync("node", [CMD], {
+      encoding: "utf8",
+      env: { ...process.env, SDD_WORK_ROOT: tmp, SDD_SOURCE_ROOT: tmp },
+    });
+
+    assert.equal(result.status, 1, `expected exit 1, got ${result.status}`);
+    const output = result.stdout + result.stderr;
+    assert.ok(
+      output.includes("bogus-preset"),
+      `expected unknown preset name in output:\n${output}`
+    );
+  });
+
+  // Requirement 7: --format json
+  it("outputs valid JSON with ok field when --format json is passed", () => {
+    tmp = createTmpDir();
+    writeJson(tmp, ".sdd-forge/config.json", VALID_CONFIG);
+
+    const result = spawnSync("node", [CMD, "--format", "json"], {
+      encoding: "utf8",
+      env: { ...process.env, SDD_WORK_ROOT: tmp, SDD_SOURCE_ROOT: tmp },
+    });
+
+    assert.equal(result.status, 0, `expected exit 0, got ${result.status}\nstderr: ${result.stderr}`);
+    let parsed;
+    assert.doesNotThrow(() => { parsed = JSON.parse(result.stdout); }, "stdout must be valid JSON");
+    assert.ok("ok" in parsed, `expected 'ok' field in JSON:\n${result.stdout}`);
+    assert.equal(parsed.ok, true);
+  });
+
+  // Requirement 7: --format json on error
+  it("outputs JSON with ok=false when --format json and config is invalid", () => {
+    tmp = createTmpDir();
+    writeJson(tmp, ".sdd-forge/config.json", {
+      type: "node-cli",
+      docs: { languages: ["ja"], defaultLanguage: "ja" },
+      // lang missing
+    });
+
+    const result = spawnSync("node", [CMD, "--format", "json"], {
+      encoding: "utf8",
+      env: { ...process.env, SDD_WORK_ROOT: tmp, SDD_SOURCE_ROOT: tmp },
+    });
+
+    assert.equal(result.status, 1, `expected exit 1, got ${result.status}`);
+    let parsed;
+    assert.doesNotThrow(() => { parsed = JSON.parse(result.stdout); }, "stdout must be valid JSON");
+    assert.equal(parsed.ok, false);
+    assert.ok(Array.isArray(parsed.checks), `expected 'checks' array in JSON:\n${result.stdout}`);
+  });
+
+  // Requirement 8: --help
+  it("displays help with -h and exits 0", () => {
+    const result = spawnSync("node", [CMD, "-h"], {
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, `expected exit 0, got ${result.status}`);
+    assert.ok(
+      result.stdout.includes("Usage"),
+      `expected Usage in help output:\n${result.stdout}`
+    );
+  });
+});

--- a/src/check.js
+++ b/src/check.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/**
+ * src/check.js
+ *
+ * Check dispatcher. Routes check subcommands to scripts under check/commands/.
+ */
+
+import path from "path";
+import { PKG_DIR } from "./lib/cli.js";
+import { EXIT_ERROR } from "./lib/exit-codes.js";
+
+/** Subcommand → script mapping */
+const SCRIPTS = {
+  config: "check/commands/config.js",
+};
+
+const args = process.argv.slice(2);
+const subCmd = args[0];
+const rest = args.slice(1);
+
+if (!subCmd || subCmd === "-h" || subCmd === "--help") {
+  console.error("Usage: sdd-forge check <command>\n");
+  console.error("Available commands:");
+  for (const c of Object.keys(SCRIPTS)) console.error(`  ${c}`);
+  console.error("\nRun: sdd-forge check <command> --help");
+  process.exit(subCmd ? 0 : 1);
+}
+
+const scriptRelPath = SCRIPTS[subCmd];
+if (!scriptRelPath) {
+  console.error(`sdd-forge check: unknown command '${subCmd}'`);
+  console.error("Run: sdd-forge check --help");
+  process.exit(EXIT_ERROR);
+}
+
+const scriptPath = path.join(PKG_DIR, scriptRelPath);
+process.argv = [process.argv[0], scriptPath, ...rest];
+
+await import(scriptPath);

--- a/src/check/commands/config.js
+++ b/src/check/commands/config.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * src/check/commands/config.js
+ *
+ * sdd-forge check config — config.json validation report.
+ *
+ * Runs three checks in order:
+ *   1. File existence and JSON parse
+ *   2. Schema validation (required fields, type constraints)
+ *   3. Preset existence (type values must match known presets)
+ */
+
+import fs from "fs";
+import { runIfDirect } from "../../lib/entrypoint.js";
+import { repoRoot, parseArgs } from "../../lib/cli.js";
+import { sddConfigPath } from "../../lib/config.js";
+import { validateConfig } from "../../lib/types.js";
+import { PRESETS } from "../../lib/presets.js";
+import { EXIT_ERROR } from "../../lib/exit-codes.js";
+
+const MAX_SCHEMA_ERRORS = 50;
+
+function printHelp() {
+  console.log(
+    [
+      "Usage: sdd-forge check config [options]",
+      "",
+      "Validate .sdd-forge/config.json for required fields, preset existence,",
+      "and schema consistency.",
+      "",
+      "Options:",
+      "  --format <text|json>  Output format (default: text)",
+      "  -h, --help            Show this help",
+    ].join("\n")
+  );
+}
+
+/**
+ * Run all config checks and return check results.
+ * Stops early if file or schema check fails.
+ *
+ * @param {string} root - repo root
+ * @returns {{ name: string, result: "pass"|"fail", errors: string[] }[]}
+ */
+function runChecks(root) {
+  const configPath = sddConfigPath(root);
+  const checks = [];
+
+  // Check 1: file existence + JSON parse
+  if (!fs.existsSync(configPath)) {
+    checks.push({ name: "file", result: "fail", errors: [`config.json not found: ${configPath}`] });
+    return checks;
+  }
+
+  let raw;
+  try {
+    raw = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  } catch (err) {
+    checks.push({ name: "file", result: "fail", errors: [`Failed to parse config.json: ${err.message}`] });
+    return checks;
+  }
+  checks.push({ name: "file", result: "pass", errors: [] });
+
+  // Check 2: schema validation
+  try {
+    validateConfig(raw);
+    checks.push({ name: "schema", result: "pass", errors: [] });
+  } catch (err) {
+    const errors = err.message
+      .replace(/^Config validation failed:\n/, "")
+      .split(/\n\s*-\s*/)
+      .map((e) => e.trim())
+      .filter(Boolean)
+      .slice(0, MAX_SCHEMA_ERRORS);
+    checks.push({ name: "schema", result: "fail", errors });
+    return checks;
+  }
+
+  // Check 3: preset existence
+  const types = Array.isArray(raw.type) ? raw.type : [raw.type];
+  const validKeys = new Set(PRESETS.map((p) => p.key));
+  const unknownPresets = types.filter((t) => !validKeys.has(t));
+
+  if (unknownPresets.length > 0) {
+    checks.push({
+      name: "presets",
+      result: "fail",
+      errors: unknownPresets.map((t) => `Preset not found: ${t}`),
+    });
+  } else {
+    checks.push({ name: "presets", result: "pass", errors: [] });
+  }
+
+  return checks;
+}
+
+async function main() {
+  const cli = parseArgs(process.argv.slice(2), {
+    options: ["--format"],
+    defaults: { format: "text" },
+  });
+
+  if (cli.help) {
+    printHelp();
+    return;
+  }
+
+  const format = cli.format || "text";
+  if (!["text", "json"].includes(format)) {
+    process.stderr.write(`sdd-forge check config: unknown format '${format}'. Use text or json.\n`);
+    process.exit(EXIT_ERROR);
+  }
+
+  const root = repoRoot();
+  const checks = runChecks(root);
+  const ok = checks.every((c) => c.result === "pass");
+
+  if (format === "json") {
+    process.stdout.write(JSON.stringify({ ok, checks }, null, 2) + "\n");
+    if (!ok) process.exit(EXIT_ERROR);
+    return;
+  }
+
+  // text format
+  if (ok) {
+    process.stdout.write("config is valid\n");
+  } else {
+    for (const check of checks) {
+      if (check.result === "fail") {
+        for (const err of check.errors) {
+          process.stderr.write(`  - ${err}\n`);
+        }
+      }
+    }
+    process.exit(EXIT_ERROR);
+  }
+}
+
+export { main };
+runIfDirect(import.meta.url, main);

--- a/src/sdd-forge.js
+++ b/src/sdd-forge.js
@@ -6,6 +6,7 @@
  * Routes top-level subcommands to dedicated dispatchers:
  *   docs    → src/docs.js
  *   flow    → src/flow.js
+ *   check   → src/check.js
  *   setup   → src/setup.js
  *   upgrade → src/upgrade.js
  *   help    → src/help.js
@@ -45,10 +46,13 @@ try {
     process.stderr.write("[sdd-forge] WARN: cfg.logs.prompts is deprecated. Use cfg.logs.enabled instead.\n");
   }
   Logger.getInstance().init(root, cfg, { entryCommand });
-} catch { /* pre-setup or missing config — Logger stays uninitialized, logs silently skipped */ }
+} catch (err) {
+  /* pre-setup or missing config — Logger stays uninitialized */
+  if (err?.code !== "ERR_MISSING_FILE") process.stderr.write(`[sdd-forge] Logger init failed: ${err?.message}\n`);
+}
 
 /** Namespace dispatchers — receive subcommand + rest args */
-const NAMESPACE_DISPATCHERS = new Set(["docs", "flow"]);
+const NAMESPACE_DISPATCHERS = new Set(["docs", "flow", "check"]);
 
 /** Independent commands — receive rest args directly */
 const INDEPENDENT = {


### PR DESCRIPTION
fixes #115

## Goal

`sdd-forge check config` コマンドを実装する。`.sdd-forge/config.json` の妥当性を3段階（JSONパース → スキーマ検証 → preset存在確認）で診断し、問題を明確なエラーメッセージで報告する。

## Requirements

1. `sdd-forge check config` コマンドが実行できること
2. `config.json` が存在しない場合、エラーメッセージを stderr に出力して exit 1 すること
3. `config.json` が無効な JSON の場合、パースエラーを報告して exit 1 すること
4. スキーマ検証エラーがある場合、最大50件までエラーを列挙して exit 1 すること
5. `type` に指定されたプリセットが存在しない場合、該当プリセット名を報告して exit 1 すること
6. 全チェックがパスした場合、"config is valid" を表示して exit 0 すること
7. `--format json` オプションで JSON 形式の出力ができること
8. `-h` / `--help` でヘルプを表示すること

## Scope

- `src/check.js` の `SCRIPTS` マップへの `config` エントリ追加
- `src/check/commands/config.js` の新規作成
- 出力フォーマット: `text`（デフォルト）、`json`
- 診断チェック:
  1. config.json の存在・JSONパース検証
  2. スキーマ検証（既存 `validateConfig()` を再利用）
  3. `type` フィールドのプリセット存在確認（既存 `PRESETS` を再利用）